### PR TITLE
new functions 'setup_emission_raster' scale_method: classarea and classfraction 

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -22,6 +22,8 @@ Added
 - ``DEmissionGeometryComponent`` to handle geometry properties of the demission model.
 - ``DelwaqForcingComponent`` and ``DEmissionForcingComponent`` to handle hydrological, sediment and climate forcing data.
 - Readers for ``pointer``, ``forcing`` (netcdf copy) and ``geometry`` components.
+- New methods ``classarea`` and ``classfraction`` for emission raster resampling in ``setup_emission_raster``.
+- Flexible output variable name in ``setup_emission_vector`` and ``setup_emission_mapping``.
 
 Changed
 -------

--- a/hydromt_delwaq/demission.py
+++ b/hydromt_delwaq/demission.py
@@ -357,10 +357,11 @@ class DemissionModel(Model):
         self,
         emission_fn: str | Path | xr.DataArray,
         scale_method: str = "average",
-        classnumber=0.0,
+        classnumber: int | float = 0.0,
         fillna_method: str = "zero",
-        fillna_value: int = 0.0,
+        fillna_value: int | float = 0.0,
         area_division: bool = False,
+        output_name: str | None = None,
     ):
         """Prepare one or several emission map from raster data.
 
@@ -372,18 +373,21 @@ class DemissionModel(Model):
         ----------
         emission_fn : {'GHS-POP_2015'...}
             Name of raster emission map source.
-        scale_method : str {'nearest', 'average', 'mode'}
-            Method for resampling
-        classnumber : float
+        scale_method : str {'nearest', 'average', 'mode', 'classfraction', 'classarea'}
+            Method for resampling. Either nearest neighbour, average, mode, or class
+            fraction/area [m2] for categorical data.
+        classnumber : int | float
             Class number used for resampling methods 'classfraction' or 'classarea'.
         fillna_method : str {'nearest', 'zero', 'value'}
             Method to fill NaN values. Either nearest neighbour, zeros or user defined
             value.
-        fillna_value : float
+        fillna_value : int | float
             If fillna_method is set to 'value', NaNs in the emission maps will be
             replaced by this value.
         area_division : boolean
             If needed do the resampling in cap/m2 (True) instead of cap (False)
+        output_name : str, optional
+            Name of the output variable. If None, use emission_fn name.
         """
         logger.info(f"Preparing '{emission_fn}' map.")
         # process raster emission maps
@@ -399,7 +403,7 @@ class DemissionModel(Model):
             fillna_value=fillna_value,
             area_division=area_division,
         )
-        ds_emi = ds_emi.to_dataset(name=emission_fn)
+        ds_emi = ds_emi.to_dataset(name=output_name or emission_fn)
         self.staticdata.set(ds_emi)
 
     @hydromt_step
@@ -408,6 +412,7 @@ class DemissionModel(Model):
         emission_fn: str | xr.DataArray,
         col2raster: str = "",
         rasterize_method: str = "value",
+        output_name: str | None = None,
     ):
         """Prepare emission map from vector data.
 
@@ -427,7 +432,10 @@ class DemissionModel(Model):
             If "value", the value from the col2raster is used directly in the raster.
             If "fraction", the fraction of the grid cell covered by the vector file is
             returned.
-            If "area", the area of the grid cell covered by the vector file is returned.
+            If "area", the area of the grid cell covered by the vector file is returned
+            [m2].
+        output_name : str, optional
+            Name of the output variable. If None, use emission_fn name.
         """
         logger.info(f"Preparing '{emission_fn}' map.")
         gdf_org = self.data_catalog.get_geodataframe(
@@ -449,7 +457,7 @@ class DemissionModel(Model):
                 method=rasterize_method,
                 mask_name="mask",
             )
-        ds_emi = ds_emi.to_dataset(name=emission_fn)
+        ds_emi = ds_emi.to_dataset(name=output_name or emission_fn)
         self.staticdata.set(ds_emi)
 
     @hydromt_step

--- a/hydromt_delwaq/demission.py
+++ b/hydromt_delwaq/demission.py
@@ -357,6 +357,7 @@ class DemissionModel(Model):
         self,
         emission_fn: str | Path | xr.DataArray,
         scale_method: str = "average",
+        classnumber=0.0,
         fillna_method: str = "zero",
         fillna_value: int = 0.0,
         area_division: bool = False,
@@ -373,6 +374,8 @@ class DemissionModel(Model):
             Name of raster emission map source.
         scale_method : str {'nearest', 'average', 'mode'}
             Method for resampling
+        classnumber : float
+            Class number used for resampling methods 'classfraction' or 'classarea'.
         fillna_method : str {'nearest', 'zero', 'value'}
             Method to fill NaN values. Either nearest neighbour, zeros or user defined
             value.
@@ -391,6 +394,7 @@ class DemissionModel(Model):
             da=da,
             ds_like=self.staticdata.data,
             method=scale_method,
+            classnumber=classnumber,
             fillna_method=fillna_method,
             fillna_value=fillna_value,
             area_division=area_division,

--- a/hydromt_delwaq/workflows/emissions.py
+++ b/hydromt_delwaq/workflows/emissions.py
@@ -144,16 +144,25 @@ def emission_raster(
         da = da.astype("int32")
         # return 1 for classnumber, NULL for all other classes
         da_boolean = da.where(da.values == classnumber, 0) / classnumber
-        # convert to area
-        da_area = da_boolean * gridarea(da)
-        # Reproject using sum
-        da_out = da_area.raster.reproject_like(ds_like, method="sum")
-        if method == "classfraction":
-            # convert to fraction using area at model resolution
-            da_area_model = gridarea(ds_like)
-            da_out = da_out / da_area_model
-            # Max at 1 (avoid rounding errors)
-            da_out = da_out.where(da_out.values <= 1.0, 1.0)
+        # High resolution raster
+        if da.raster.res[0] < ds_like.raster.res[0]:
+            # convert to area
+            da_area = da_boolean * gridarea(da)
+            # Reproject using sum
+            da_out = da_area.raster.reproject_like(ds_like, method="sum")
+            if method == "classfraction":
+                # convert to fraction using area at model resolution
+                da_area_model = gridarea(ds_like)
+                da_out = da_out / da_area_model
+                # Max at 1 (avoid rounding errors)
+                da_out = da_out.where(da_out.values <= 1.0, 1.0)
+        else:
+            # Reproject using average
+            da_out = da_boolean.raster.reproject_like(ds_like, method="average")
+            if method == "classarea":
+                # convert to area using area at model resolution
+                da_area_model = gridarea(ds_like)
+                da_out = da_out * da_area_model
         # Change dtype now to float32
         da_out = da_out.astype("float32")
 

--- a/hydromt_delwaq/workflows/emissions.py
+++ b/hydromt_delwaq/workflows/emissions.py
@@ -128,66 +128,42 @@ def emission_raster(
         else:
             nodata = -999.0
         da.raster.set_nodata(nodata)
-
+        
+    if method == "classfraction" or method == "classarea":
+        area_division = False
+        
     if area_division:
         da_area = gridarea(da)
         da = da / da_area
 
     logger.info(f"Deriving {da.name} using {method} resampling (nodata={nodata}).")
 
-    if method == "classfraction" or method == "classarea" :
+    if method == "classfraction" or method == "classarea":
         da = da.astype('int32')
-        # return 1 for classnumber, 0 for all other classes
+        # return 1 for classnumber, NULL for all other classes
         da_boolean = da.where(da.values == classnumber) / classnumber
         gdf = da_boolean.raster.vectorize() #gis.DataArray.raster.vectorize
-        # remove classes (all other classes) assigned value zero
+        # remove classes (all other classes) assigned value null
         gdf = gdf[gdf.value.notnull()]
         #gdf.to_file("output.gpkg", driver="GPKG")
-        # Using the vectors directly (long computation time but most accurate)
-        # Create vector grid (for calculating fraction and storage per grid cell)
-        logger.debug(
-            "Creating vector grid for calculating coverage fraction per grid cell"
-        )
-        gdf["geometry"] = gdf.geometry.buffer(0)  # fix potential geometry errors
-        msktn = ds_like["mask"]
-        idx_valid = np.where(msktn.values.flatten() != msktn.raster.nodata)[0]
-        gdf_grid = ds_like.raster.vector_grid().loc[idx_valid]
-        gdf_grid["coverfrac"] = np.zeros(len(idx_valid))
-        gdf_grid["area"] = gdf_grid.to_crs(
-            3857
-        ).area  # area calculation in projected crs
-
-        # Calculate fraction per (vector) grid cell
-        # Looping over each vector shape
-        for i in range(len(gdf)):
-            print("calculating "+str(i)+" of "+str(len(gdf))+
-                    " ({:.2f}".format(i/len(gdf)*100)+"%)")
-            shape = gdf.iloc[i]
-            gridded_shape = gdf_grid.intersection(shape.geometry)
-            gridded_shape = gridded_shape.loc[~gridded_shape.is_empty]
-            idxs = gridded_shape.index
-            if np.any(idxs):
-                # area calculation needs projected crs
-                sharea_cell = gridded_shape.to_crs(3857).area
-                gdf_grid.loc[idxs, "coverfrac"] += (
-                    sharea_cell / gdf_grid.loc[idxs, "area"]
-                )
-        # Create the rasterized coverage fraction map
-        da_out = ds_like.raster.rasterize(
-            gdf_grid,
-            col_name="coverfrac",
-            nodata=0,
-            all_touched=False,
-            dtype=None,
-            sindex=False,
-        )
-        if method == "classarea" :
-            # Create the rasterized coverage area map (coverage fraction * area in km2)
-            da_area = gridarea(da_out)
-            da_out = da_out * da_area * 0.000001 # km2
         
+        if method == "classfraction":
+            # Creating rasterized coverage fraction map (fraction per grid cell)
+            rasterize_method = "fraction"
+        elif method == "classarea":
+            # Create the rasterized coverage area map (coverage fraction * area in m2 per gridcell)
+            rasterize_method = "area"
+        col2raster = "value"
+        da_out = emission_vector(
+            gdf=gdf,
+            ds_like=ds_like,
+            col_name=col2raster,
+            method=rasterize_method,
+            mask_name="mask",
+        )
     else: #method is 'average', 'nearest' or 'mode'
         da_out = da.raster.reproject_like(ds_like, method=method)
+    
     if area_division:
         da_area = gridarea(da_out)
         da_out = da_out * da_area

--- a/hydromt_delwaq/workflows/emissions.py
+++ b/hydromt_delwaq/workflows/emissions.py
@@ -160,7 +160,8 @@ def emission_raster(
         # Calculate fraction per (vector) grid cell
         # Looping over each vector shape
         for i in range(len(gdf)):
-            print("calculating "+str(i)+" of "+str(len(gdf))+" ({:.2f}".format(i/len(gdf)*100)+"%)")
+            print("calculating "+str(i)+" of "+str(len(gdf))+
+                    " ({:.2f}".format(i/len(gdf)*100)+"%)")
             shape = gdf.iloc[i]
             gridded_shape = gdf_grid.intersection(shape.geometry)
             gridded_shape = gridded_shape.loc[~gridded_shape.is_empty]
@@ -186,7 +187,7 @@ def emission_raster(
             da_out = da_out * da_area * 0.000001 # km2
         
     else: #method is 'average', 'nearest' or 'mode'
-	    da_out = da.raster.reproject_like(ds_like, method=method)
+        da_out = da.raster.reproject_like(ds_like, method=method)
     if area_division:
         da_area = gridarea(da_out)
         da_out = da_out * da_area

--- a/hydromt_delwaq/workflows/emissions.py
+++ b/hydromt_delwaq/workflows/emissions.py
@@ -128,10 +128,10 @@ def emission_raster(
         else:
             nodata = -999.0
         da.raster.set_nodata(nodata)
-        
+
     if method == "classfraction" or method == "classarea":
         area_division = False
-        
+
     if area_division:
         da_area = gridarea(da)
         da = da / da_area
@@ -139,19 +139,20 @@ def emission_raster(
     logger.info(f"Deriving {da.name} using {method} resampling (nodata={nodata}).")
 
     if method == "classfraction" or method == "classarea":
-        da = da.astype('int32')
+        da = da.astype("int32")
         # return 1 for classnumber, NULL for all other classes
         da_boolean = da.where(da.values == classnumber) / classnumber
-        gdf = da_boolean.raster.vectorize() #gis.DataArray.raster.vectorize
+        gdf = da_boolean.raster.vectorize()  # gis.DataArray.raster.vectorize
         # remove classes (all other classes) assigned value null
         gdf = gdf[gdf.value.notnull()]
-        #gdf.to_file("output.gpkg", driver="GPKG")
-        
+        # gdf.to_file("output.gpkg", driver="GPKG")
+
         if method == "classfraction":
             # Creating rasterized coverage fraction map (fraction per grid cell)
             rasterize_method = "fraction"
         elif method == "classarea":
-            # Create the rasterized coverage area map (coverage fraction * area in m2 per gridcell)
+            # Create the rasterized coverage area map
+            # (coverage fraction * area in m2 per gridcell)
             rasterize_method = "area"
         col2raster = "value"
         da_out = emission_vector(
@@ -161,9 +162,9 @@ def emission_raster(
             method=rasterize_method,
             mask_name="mask",
         )
-    else: #method is 'average', 'nearest' or 'mode'
+    else:  # method is 'average', 'nearest' or 'mode'
         da_out = da.raster.reproject_like(ds_like, method=method)
-    
+
     if area_division:
         da_area = gridarea(da_out)
         da_out = da_out * da_area

--- a/hydromt_delwaq/workflows/emissions.py
+++ b/hydromt_delwaq/workflows/emissions.py
@@ -79,6 +79,7 @@ def emission_raster(
     da,
     ds_like,
     method="average",
+    classnumber=0.0,
     fillna_method="nearest",
     fillna_value=0.0,
     area_division=False,
@@ -94,8 +95,10 @@ def emission_raster(
         DataArray containing emission map.
     ds_like : xarray.DataArray
         Dataset at model resolution.
-    method : str {'average', 'nearest', 'mode'}
+    method : str {'average', 'nearest', 'mode', 'classfraction', 'classarea'}
         Method for resampling.
+    classnumber : float
+        Class number used for resampling methods 'classfraction' or 'classarea'.
     fillna_method : str {'nearest', 'zero', 'value'}
         Method to fill NaN values.
     fillna_value : float
@@ -131,9 +134,59 @@ def emission_raster(
         da = da / da_area
 
     logger.info(f"Deriving {da.name} using {method} resampling (nodata={nodata}).")
-    # da = da.astype(np.float32)
 
-    da_out = da.raster.reproject_like(ds_like, method=method)
+    if method == "classfraction" or method == "classarea" :
+        da = da.astype('int32')
+        # return 1 for classnumber, 0 for all other classes
+        da_boolean = da.where(da.values == classnumber) / classnumber
+        gdf = da_boolean.raster.vectorize() #gis.DataArray.raster.vectorize
+        # remove classes (all other classes) assigned value zero
+        gdf = gdf[gdf.value.notnull()]
+        #gdf.to_file("output.gpkg", driver="GPKG")
+        # Using the vectors directly (long computation time but most accurate)
+        # Create vector grid (for calculating fraction and storage per grid cell)
+        logger.debug(
+            "Creating vector grid for calculating coverage fraction per grid cell"
+        )
+        gdf["geometry"] = gdf.geometry.buffer(0)  # fix potential geometry errors
+        msktn = ds_like["mask"]
+        idx_valid = np.where(msktn.values.flatten() != msktn.raster.nodata)[0]
+        gdf_grid = ds_like.raster.vector_grid().loc[idx_valid]
+        gdf_grid["coverfrac"] = np.zeros(len(idx_valid))
+        gdf_grid["area"] = gdf_grid.to_crs(
+            3857
+        ).area  # area calculation in projected crs
+
+        # Calculate fraction per (vector) grid cell
+        # Looping over each vector shape
+        for i in range(len(gdf)):
+            print("calculating "+str(i)+" of "+str(len(gdf))+" ({:.2f}".format(i/len(gdf)*100)+"%)")
+            shape = gdf.iloc[i]
+            gridded_shape = gdf_grid.intersection(shape.geometry)
+            gridded_shape = gridded_shape.loc[~gridded_shape.is_empty]
+            idxs = gridded_shape.index
+            if np.any(idxs):
+                # area calculation needs projected crs
+                sharea_cell = gridded_shape.to_crs(3857).area
+                gdf_grid.loc[idxs, "coverfrac"] += (
+                    sharea_cell / gdf_grid.loc[idxs, "area"]
+                )
+        # Create the rasterized coverage fraction map
+        da_out = ds_like.raster.rasterize(
+            gdf_grid,
+            col_name="coverfrac",
+            nodata=0,
+            all_touched=False,
+            dtype=None,
+            sindex=False,
+        )
+        if method == "classarea" :
+            # Create the rasterized coverage area map (coverage fraction * area in km2)
+            da_area = gridarea(da_out)
+            da_out = da_out * da_area * 0.000001 # km2
+        
+    else: #method is 'average', 'nearest' or 'mode'
+	    da_out = da.raster.reproject_like(ds_like, method=method)
     if area_division:
         da_area = gridarea(da_out)
         da_out = da_out * da_area

--- a/hydromt_delwaq/workflows/emissions.py
+++ b/hydromt_delwaq/workflows/emissions.py
@@ -76,13 +76,13 @@ def gridlength_gridwidth(ds):
 
 
 def emission_raster(
-    da,
-    ds_like,
-    method="average",
-    classnumber=0.0,
-    fillna_method="nearest",
-    fillna_value=0.0,
-    area_division=False,
+    da: xr.DataArray,
+    ds_like: xr.Dataset,
+    method: str = "average",
+    fillna_method: str = "nearest",
+    classnumber: int | float = 0.0,
+    fillna_value: int | float = 0.0,
+    area_division: bool = False,
 ):
     """Return emission map.
 
@@ -97,11 +97,11 @@ def emission_raster(
         Dataset at model resolution.
     method : str {'average', 'nearest', 'mode', 'classfraction', 'classarea'}
         Method for resampling.
-    classnumber : float
+    classnumber : int | float
         Class number used for resampling methods 'classfraction' or 'classarea'.
     fillna_method : str {'nearest', 'zero', 'value'}
         Method to fill NaN values.
-    fillna_value : float
+    fillna_value : int | float
         If fillna_method is set to 'value', NaNs in the emission maps will be replaced
         by this value.
     area_division : boolean
@@ -131,6 +131,8 @@ def emission_raster(
 
     if method == "classfraction" or method == "classarea":
         area_division = False
+        # Final nodata for classfraction and classarea is -9999
+        nodata = -9999.0
 
     if area_division:
         da_area = gridarea(da)
@@ -141,29 +143,28 @@ def emission_raster(
     if method == "classfraction" or method == "classarea":
         da = da.astype("int32")
         # return 1 for classnumber, NULL for all other classes
-        da_boolean = da.where(da.values == classnumber) / classnumber
-        gdf = da_boolean.raster.vectorize()  # gis.DataArray.raster.vectorize
-        # remove classes (all other classes) assigned value null
-        gdf = gdf[gdf.value.notnull()]
-        # gdf.to_file("output.gpkg", driver="GPKG")
-
+        da_boolean = da.where(da.values == classnumber, 0) / classnumber
+        # convert to area
+        da_area = da_boolean * gridarea(da)
+        # Reproject using sum
+        da_out = da_area.raster.reproject_like(ds_like, method="sum")
         if method == "classfraction":
-            # Creating rasterized coverage fraction map (fraction per grid cell)
-            rasterize_method = "fraction"
-        elif method == "classarea":
-            # Create the rasterized coverage area map
-            # (coverage fraction * area in m2 per gridcell)
-            rasterize_method = "area"
-        col2raster = "value"
-        da_out = emission_vector(
-            gdf=gdf,
-            ds_like=ds_like,
-            col_name=col2raster,
-            method=rasterize_method,
-            mask_name="mask",
-        )
-    else:  # method is 'average', 'nearest' or 'mode'
+            # convert to fraction using area at model resolution
+            da_area_model = gridarea(ds_like)
+            da_out = da_out / da_area_model
+            # Max at 1 (avoid rounding errors)
+            da_out = da_out.where(da_out.values <= 1.0, 1.0)
+        # Change dtype now to float32
+        da_out = da_out.astype("float32")
+
+    # method is 'average', 'nearest' or 'mode'
+    elif method in ["average", "nearest", "mode"]:
         da_out = da.raster.reproject_like(ds_like, method=method)
+    else:
+        raise ValueError(
+            f"Resampling method {method} not recognized. "
+            "Choose from 'average', 'nearest', 'mode', 'classfraction', 'classarea'."
+        )
 
     if area_division:
         da_area = gridarea(da_out)

--- a/tests/test_model_methods.py
+++ b/tests/test_model_methods.py
@@ -6,6 +6,8 @@ import hydromt
 import numpy as np
 import xarray as xr
 
+from hydromt_delwaq.workflows.emissions import gridarea
+
 TESTDATADIR = join(dirname(abspath(__file__)), "data")
 
 
@@ -93,3 +95,33 @@ def test_setup_roads(example_demission_model):
     assert len(np.unique(ds["hwy_length_sum_country"].values)) == 2
     assert np.isclose(ds["hwy_length_sum_country"].values.max(), 1247.7513, atol=1e-4)
     assert np.isclose(ds["hwy_length"].values.max(), 7.6356, atol=1e-4)
+
+
+def test_setup_emission_raster(example_demission_model):
+    # Initialize model and read results
+    mod = example_demission_model
+
+    # Tests on setup_emission_raster with classfraction
+    mod.setup_emission_raster(
+        emission_fn="vito_2015",
+        scale_method="classfraction",
+        classnumber=40,  # agriculture
+    )
+    assert "vito_2015" in mod.staticdata.data
+    da = mod.staticdata.data["vito_2015"]
+    assert da.values.max() <= 1.0
+    assert np.isclose(da.values.mean(), 0.1458, atol=1e-4)
+    assert da.raster.nodata == -9999.0
+    assert da.dtype == "float32"
+
+    # Tests on setup_emission_raster with classarea
+    mod.setup_emission_raster(
+        emission_fn="vito_2015",
+        scale_method="classarea",
+        classnumber=40,
+        output_name="agriculture_area",
+    )
+    assert "agriculture_area" in mod.staticdata.data
+    da = mod.staticdata.data["agriculture_area"]
+    assert np.isclose(da.values.mean(), 348199.78, atol=1e-4)
+    assert da.values.max() <= gridarea(mod.staticdata.data).values.max()


### PR DESCRIPTION
new functions 'setup_emission_raster' scale_method: classarea (km2) and classfraction (-) for landuse class maps:
input is a raster. It is compared against a classnumber (user input), the resulting selection is vectorized, then fraction of modelgrid cell is calculated and the result is rasterized. In case of classarea the grid is multiplied by area resulting in area coverage in km2 of the selected classnumber.
The calculation of the fraction is done by looping over all vector shapes. For large grids/basins with a lot of shapes this may take long. 
Possible improvement could be 
- to use intersect instead? or 
- refering to def emission_vector with method == "fraction" or method == "area" and the created vector (after line gdf = gdf[gdf.value.notnull()] )?